### PR TITLE
fix name_to_start_end regex

### DIFF
--- a/R/interval_formatting.R
+++ b/R/interval_formatting.R
@@ -294,7 +294,7 @@ name_to_start_end <- function(name) {
   # check `name` argument
   assertthat::assert_that(
     assertive::is_character(name),
-    all(grepl("^\\[((-*Inf)|([\\-\\.0-9]+)),\\s((Inf)|([\\-\\.0-9]+))\\)$",
+    all(grepl("^\\[((-Inf)|([-.0-9]+)),\\s((Inf)|([-.0-9]+))\\)$",
               name)),
     msg = "`name` must be a character vector formatted in left-closed,
     right-open interval notation as described in `gen_name()`"
@@ -306,14 +306,14 @@ name_to_start_end <- function(name) {
   start <- gsub("^\\[", "", name)
   # remove ", ", right endpoint, right ")".
   # right endpoint can be positive infinity or any numeric
-  start <- gsub(",\\s((Inf)|([\\-\\.0-9]+))\\)$", "", start)
+  start <- gsub(",\\s((Inf)|([-.0-9]+))\\)$", "", start)
   start <- as.numeric(start)
 
   # remove right ")"
   end <- gsub("\\)$", "", name)
   # remove left "[", left endpoint, ", "
   # left endpoint can be negative infinity or any numeric
-  end <- gsub("^\\[((-Inf)|([\\-\\.0-9]+)),\\s", "", end)
+  end <- gsub("^\\[((-Inf)|([-.0-9]+)),\\s", "", end)
   end <- as.numeric(end)
 
   result <- list(start = start,

--- a/tests/testthat/test-interval_assertions.R
+++ b/tests/testthat/test-interval_assertions.R
@@ -68,3 +68,17 @@ testthat::test_that("missing intervals are identified correctly", {
   )
 
 })
+
+
+# Going from name to start and end of interval works ----------------------
+
+names <- c("[-20, 0)", "[-Inf, -20)", "[0, 10)", "[-Inf, Inf)")
+expected_result <- data.table(
+  start = c(-20, -Inf, 0, -Inf),
+  end = c(0, -20, 10, Inf)
+)
+
+testthat::test_that("interval name correctly converted to 'start' and 'end'", {
+  result <- as.data.table(name_to_start_end(names))
+  testthat::expect_identical(result, expected_result)
+})


### PR DESCRIPTION
## Describe changes

Fixes a bug in the regular expressions that was noticed while fixing `agg_lt`. The bug was identifying "-" in the interval name.

## What issues are related

Related to https://github.com/ihmeuw-demographics/lifetableMethods/issues/23

## Checklist

### Packages Repositories

* [X] Have you read the [contributing guidelines](https://github.com/ihmeuw-demographics/packageTemplate/wiki#guide-to-r-package-development) for `ihmeuw-demographics` R packages?
* [X] Have you successfully run `devtools::check()` locally?
* [X] Have you added in tests for the changes included in the PR?
* [X] Do the changes follow the `ihmeuw-demographics` [code style](https://github.com/ihmeuw-demographics/packageTemplate/wiki/Code-style-guide)?


