### PR TITLE
BUGFIX: preserve the 'col_stem' variable type

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Suggests:
     ggplot2,
     scales
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 VignetteBuilder: knitr
 Language: en-US
 Depends: R (>= 2.10)

--- a/R/categorical_trees.R
+++ b/R/categorical_trees.R
@@ -479,7 +479,11 @@ agg_subtree <- function(dt,
   if (col_type == "interval") {
     parent_dt[, paste0(col_stem, c("_start", "_end")) := name_to_start_end(parent)]
   } else {
-    parent_name_value <- type.convert(x = parent, typeof(dt[[col_stem]]))
+    # make sure parent name is same type as in the original dataset
+    parent_name_value <- utils::type.convert(
+      x = parent, as.is = TRUE,
+      typeof(dt[[col_stem]])
+    )
     parent_dt[, col_stem := parent_name_value]
     setnames(parent_dt, "col_stem", col_stem)
   }

--- a/R/categorical_trees.R
+++ b/R/categorical_trees.R
@@ -479,7 +479,8 @@ agg_subtree <- function(dt,
   if (col_type == "interval") {
     parent_dt[, paste0(col_stem, c("_start", "_end")) := name_to_start_end(parent)]
   } else {
-    parent_dt[, col_stem := parent]
+    parent_name_value <- type.convert(x = parent, typeof(dt[[col_stem]]))
+    parent_dt[, col_stem := parent_name_value]
     setnames(parent_dt, "col_stem", col_stem)
   }
   return(parent_dt)

--- a/R/categorical_trees.R
+++ b/R/categorical_trees.R
@@ -25,7 +25,7 @@
 #' be scaled are colored blue and nodes without data directly provided
 #'
 #' @return [create_agg_tree()] and [create_scale_tree()] return a
-#'   \[`data.tree()`\] with fields for whether each node has data available
+#'   \[`data.tree()`\] with attributes for whether each node has data available
 #'   ('exists') and whether aggregation to or scaling of each node is possible
 #'   ('agg_possible' or 'scale_possible'). For [create_scale_tree()], also
 #'   includes a field for whether children of each node can be scaled
@@ -188,7 +188,7 @@ create_base_tree <- function(mapping, exists, col_type) {
     }
   }
 
-  # create left and right endpoint fields for interval trees
+  # create left and right endpoint attributes for interval trees
   if (col_type == "interval") {
     parsed_name <- name_to_start_end(tree$Get("name"))
     tree$Set(left = parsed_name$start)
@@ -245,7 +245,7 @@ vis_tree <- function(tree) {
 
   # determine whether this is an aggregate or scale tree
   type <- "agg"
-  if ("scale_possible" %in% tree$fieldsAll) type <- "scale"
+  if ("scale_possible" %in% tree$attributesAll) type <- "scale"
 
   # create node attribute for three types of nodes
   group_node <- function(x) {
@@ -318,7 +318,7 @@ identify_missing_agg <- function(tree) {
 #' @rdname problematic_tree_nodes
 identify_missing_scale <- function(tree) {
 
-  if (all(c("left", "right") %in% tree$fields)) {
+  if (all(c("left", "right") %in% tree$attributes)) {
     col_type <- "interval"
   } else {
     col_type <- "categorical"

--- a/R/interval_collapse.R
+++ b/R/interval_collapse.R
@@ -262,6 +262,7 @@ identify_common_intervals <- function(dt,
     return(split_dt)
   })
   intervals <- unique(intervals)
+  intervals <- intervals[mapply(function(ints_dt) nrow(ints_dt) > 0, intervals)]
 
   check_each_pair <- function(ints_dt1, ints_dt2) {
     ints1 <- intervals::Intervals_full(as.matrix(ints_dt1),

--- a/R/interval_trees.R
+++ b/R/interval_trees.R
@@ -117,7 +117,7 @@ create_scale_interval_tree <- function(data_intervals_dt, col_stem) {
 #' @param name \[`character(1)`\]\cr
 #'   name of the node in interval notation.
 #'
-#' @return \[`data.tree()`\] node with 'name', 'left', 'right' fields.
+#' @return \[`data.tree()`\] node with 'name', 'left', 'right' attributes
 create_interval_node <- function(start, end, name) {
   new_node <- data.tree::Node$new(name)
   new_node$Set(left = start)

--- a/man/create_interval_node.Rd
+++ b/man/create_interval_node.Rd
@@ -17,7 +17,7 @@ the right endpoint of the interval tree node.}
 name of the node in interval notation.}
 }
 \value{
-[\code{data.tree()}] node with 'name', 'left', 'right' fields.
+[\code{data.tree()}] node with 'name', 'left', 'right' attributes
 }
 \description{
 Create a node for an interval tree

--- a/man/create_tree.Rd
+++ b/man/create_tree.Rd
@@ -37,7 +37,7 @@ errors out due to missing data.}
 }
 \value{
 \code{\link[=create_agg_tree]{create_agg_tree()}} and \code{\link[=create_scale_tree]{create_scale_tree()}} return a
-[\code{data.tree()}] with fields for whether each node has data available
+[\code{data.tree()}] with attributes for whether each node has data available
 ('exists') and whether aggregation to or scaling of each node is possible
 ('agg_possible' or 'scale_possible'). For \code{\link[=create_scale_tree]{create_scale_tree()}}, also
 includes a field for whether children of each node can be scaled

--- a/tests/testthat/test_agg_scale.R
+++ b/tests/testthat/test_agg_scale.R
@@ -704,3 +704,30 @@ test_that(description, {
                      collapse_missing = TRUE),
                regexp = "input data is missing in `dt`")
 })
+
+
+# Test numeric "categorical" variable scaling -----------------------------
+
+input_dt <- data.table(
+  location_id = 1:3,
+  sex = "all"
+)
+input_dt[, value := rnorm(.N)]
+
+mapping <- data.table(
+  child = 2:3,
+  parent = 1
+)
+
+test_that("numeric 'categorical' variable works", {
+  expect_silent(
+    scale(
+      dt = input_dt,
+      id_cols = c("location_id", "sex"),
+      value_cols = "value",
+      col_stem = "location_id",
+      col_type = "categorical",
+      mapping = mapping
+    )
+  )
+})

--- a/tests/testthat/test_agg_scale.R
+++ b/tests/testthat/test_agg_scale.R
@@ -720,7 +720,7 @@ mapping <- data.table(
 )
 
 test_that("numeric 'categorical' variable works", {
-  expect_silent(
+  expect_error(
     scale(
       dt = input_dt,
       id_cols = c("location_id", "sex"),
@@ -728,6 +728,7 @@ test_that("numeric 'categorical' variable works", {
       col_stem = "location_id",
       col_type = "categorical",
       mapping = mapping
-    )
+    ),
+    NA
   )
 })


### PR DESCRIPTION
## Describe changes

This fixes an issue when scaling or aggregating when `col_stem` was equal to a numeric variable like 'location_id'. The `data.tree` functions would convert the variable to a character automatically but we want to preserve the original type for the aggregated dataset. 

This was causing the functions to break later in `scale` when merging the new values to the old dataset.

Installed locally to the v2020.0.7 image for now

## Checklist

<!-- You can erase any parts of this checklist that are not applicable to your PR. -->

### Packages Repositories

* [x] Have you read the [contributing guidelines](https://github.com/ihmeuw-demographics/packageTemplate/wiki#guide-to-r-package-development) for `ihmeuw-demographics` R packages?
* [x] Have you successfully run `devtools::check()` locally?
* [x] Have you updated or added function (and vignette if applicable) documentation? Did you update the 'man' and 'NAMESPACE' files with `devtools::document()`?
* [x] Have you added in tests for the changes included in the PR?
* [x] Do the changes follow the `ihmeuw-demographics` [code style](https://github.com/ihmeuw-demographics/packageTemplate/wiki/Code-style-guide)?
* [ ] Do your changes need to be immediately included in a new build of [`docker-base`](https://github.com/ihmeuw-demographics/docker-base) or [`docker-internal`](https://github.com/ihmeuw-demographics/docker-internal)? If so follow directions in those repositories to rebuild and redeploy the images.
