### PR TITLE
Aggregation performance vignette

### DIFF
--- a/R/categorical_trees.R
+++ b/R/categorical_trees.R
@@ -694,6 +694,8 @@ check_agg_scale_subtree_dt <- function(dt,
   expected_col_stem <- utils::type.convert(x = expected_col_stem, col_value_type)
 
   # determine the expected dataset
+  # TODO: switch to official data.table CJ with data.table inputs once available
+  # https://github.com/Rdatatable/data.table/issues/1717
   expected_dt <- dt[, list(col_stem = expected_col_stem), by = by_id_cols]
   data.table::setnames(expected_dt, "col_stem", col_stem)
   expected_dt[, data_expected := TRUE]
@@ -701,11 +703,7 @@ check_agg_scale_subtree_dt <- function(dt,
   # combine actual and expected datasets
   dt[, data_exists := TRUE]
   diagnostic_id_cols <- c(by_id_cols, col_stem)
-  diagnostic_dt <- merge(
-    dt, expected_dt,
-    all = T,
-    by = diagnostic_id_cols
-  )
+  diagnostic_dt <- dt[expected_dt, on = diagnostic_id_cols]
   diagnostic_dt[is.na(data_exists), data_exists := FALSE]
   diagnostic_dt[is.na(data_expected), data_expected := FALSE]
 

--- a/R/interval_formatting.R
+++ b/R/interval_formatting.R
@@ -95,8 +95,10 @@ gen_end <- function(dt, id_cols, col_stem, right_most_endpoint = Inf) {
   assertthat::assert_that(!end_col %in% names(dt),
                           msg = paste0("'", end_col,
                                        "' column already in `dt`"))
-  assertive::assert_is_numeric(dt[[start_col]])
-  assertive::assert_all_are_not_na(dt[[start_col]])
+  assertthat::assert_that(
+    assertive::is_numeric(dt[[start_col]]),
+    all(!is.na(dt[[start_col]]))
+  )
   demUtils::assert_is_unique_dt(dt, id_cols)
 
   # Calculate left-closed endpoints -----------------------------------------
@@ -128,8 +130,10 @@ gen_end <- function(dt, id_cols, col_stem, right_most_endpoint = Inf) {
   data.table::setnames(dt, "start_col", start_col)
 
   # check new column
-  assertive::assert_is_numeric(dt[[end_col]])
-  assertive::assert_all_are_not_na(dt[[end_col]])
+  assertthat::assert_that(
+    assertive::is_numeric(dt[[end_col]]),
+    all(!is.na(dt[[end_col]]))
+  )
 
   # put end_col to the right of start_col
   new_col_order <- append(original_col_order, end_col,
@@ -162,10 +166,14 @@ gen_length <- function(dt, col_stem) {
   assertthat::assert_that(!length_col %in% names(dt),
                           msg = paste0("'", length_col,
                                        "' column already in `dt`"))
-  assertive::assert_is_numeric(dt[[start_col]])
-  assertive::assert_all_are_not_na(dt[[start_col]])
-  assertive::assert_is_numeric(dt[[end_col]])
-  assertive::assert_all_are_not_na(dt[[end_col]])
+  assertthat::assert_that(
+    assertive::is_numeric(dt[[start_col]]),
+    all(!is.na(dt[[start_col]]))
+  )
+  assertthat::assert_that(
+    assertive::is_numeric(dt[[end_col]]),
+    all(!is.na(dt[[end_col]]))
+  )
 
   # Calculate interval length column ----------------------------------------
 
@@ -179,8 +187,10 @@ gen_length <- function(dt, col_stem) {
   data.table::setnames(dt, "length_col", length_col)
 
   # check new column
-  assertive::assert_is_numeric(dt[[length_col]])
-  assertive::assert_all_are_not_na(dt[[length_col]])
+  assertthat::assert_that(
+    assertive::is_numeric(dt[[length_col]]),
+    all(!is.na(dt[[length_col]]))
+  )
 
   # put length_col to the right of end_col
   new_col_order <- append(original_col_order, length_col,
@@ -236,10 +246,14 @@ gen_name <- function(dt,
   assertthat::assert_that(!name_col %in% names(dt),
                           msg = paste0("'", name_col,
                                        "' column already in `dt`"))
-  assertive::assert_is_numeric(dt[[start_col]])
-  assertive::assert_all_are_not_na(dt[[start_col]])
-  assertive::assert_is_numeric(dt[[end_col]])
-  assertive::assert_all_are_not_na(dt[[end_col]])
+  assertthat::assert_that(
+    assertive::is_numeric(dt[[start_col]]),
+    all(!is.na(dt[[start_col]]))
+  )
+  assertthat::assert_that(
+    assertive::is_numeric(dt[[end_col]]),
+    all(!is.na(dt[[end_col]]))
+  )
 
   # Calculate age name column -----------------------------------------------
 
@@ -269,7 +283,9 @@ gen_name <- function(dt,
 
   # check new column
   assertive::assert_is_character(dt[[name_col]])
-  assertive::assert_all_are_not_na(dt[[name_col]])
+  assertthat::assert_that(
+    all(!is.na(dt[[name_col]]))
+  )
 
   # put name_col to the right of end_col
   new_col_order <- append(original_col_order, name_col,

--- a/vignettes/agg_scale_performance.Rmd
+++ b/vignettes/agg_scale_performance.Rmd
@@ -1,0 +1,175 @@
+---
+title: "Aggregation/Scaling performance"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Aggregation/Scaling performance}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+  
+Aggregations and scaling with `hierarchyUtils` should perform as fast as basic data.table code.
+For basic use cases there should only be slightly more overhead due to the assertions and added flexibility included in `hierarchyUtils`.
+
+```{r, include=FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  echo = FALSE,
+  message = FALSE,
+  comment = "#>"
+)
+```
+
+```{r setup}
+library(hierarchyUtils)
+library(data.table)
+
+profile_n_draws <- c(1, 10)
+```
+
+```{r time_aggregation_function}
+time_aggregation <- function(n_draws,
+                             id_vars,
+                             col_stem,
+                             col_type,
+                             mapping) {
+  
+  # create input dataset
+  id_vars <- copy(id_vars)
+  id_vars[["draw"]] <- 1:n_draws
+  input_dt <- do.call(CJ, id_vars)
+  
+  # add interval end columns
+  input_dt[, year_end := year_start + 1]
+  input_dt[, age_end := age_start + 1]
+  input_dt[age_start == 95, age_end := Inf]
+  
+  # identify value and id cols
+  value_cols <- grep("value", names(input_dt), value = TRUE)
+  id_cols <- names(input_dt)[!names(input_dt) %in% value_cols]
+  
+  # time hierarchyUtils aggregation function
+  start_time <- proc.time()
+  hierarchyUtils_output_dt <- agg(
+    dt = input_dt,
+    id_cols = id_cols, value_cols = value_cols,
+    col_stem = col_stem, col_type = col_type,
+    mapping = mapping
+  )
+  end_time <- proc.time()
+  hierarchyUtils_time <- end_time - start_time
+  
+  # time basic data.table aggregation
+  start_time <- proc.time()
+  
+  cols <- col_stem
+  if (col_type == "interval") {
+    cols <- paste0(col_stem, "_", c("start", "end"))
+  }
+  by_id_cols <- id_cols[!id_cols %in% cols]
+
+  if (col_type == "interval") {
+    
+    data.table_output_dt <- lapply(1:nrow(mapping), function(i) {
+      start_bound <- mapping[i, get(cols[1])]
+      end_bound <- mapping[i, get(cols[2])]
+    
+      agg_dt <- input_dt[
+        get(cols[1]) >= start_bound & get(cols[2]) <= end_bound,
+        lapply(.SD, sum), .SDcols = value_cols,
+        by = by_id_cols
+      ]
+      agg_dt[, c(cols) := list(start_bound, end_bound)]
+      return(agg_dt)
+    })
+    data.table_output_dt <- rbindlist(data.table_output_dt)
+    
+  } else {
+    
+    data.table_output_dt <- input_dt[
+      get(col_stem) %in% mapping[, child],
+      lapply(.SD, sum), .SDcols = value_cols,
+      by = by_id_cols
+    ]
+    data.table_output_dt[, c(col_stem) := list(mapping[, unique(parent)])]
+  }
+  end_time <- proc.time()
+  data.table_time <- end_time - start_time
+  
+  # check that outputs are the same
+  setcolorder(hierarchyUtils_output_dt, c(id_cols, value_cols))
+  setkeyv(hierarchyUtils_output_dt, id_cols)
+  setcolorder(data.table_output_dt, c(id_cols, value_cols))
+  setkeyv(data.table_output_dt, id_cols)
+  testthat::expect_identical(hierarchyUtils_output_dt, data.table_output_dt)
+
+  # compile together timings in formatted table
+  timings <- lapply(c("hierarchyUtils", "data.table"), function(method) {
+    elapsed_time <- get(paste0(method, "_time"))
+    elapsed_time <- as.list(elapsed_time)
+    setDT(elapsed_time)
+    elapsed_time[, method := method]
+    elapsed_time[, c("col_stem", "col_type") := list(col_stem, col_type)]
+    elapsed_time[, n_draws := format(n_draws, big.mark = ",", scientific = FALSE)]
+    elapsed_time[, n_input_rows := format(nrow(input_dt), big.mark = ",", scientific = FALSE)]
+  })
+  timings <- rbindlist(timings)
+  return(timings)
+}
+```
+
+```{r time_aggregations}
+# default variables for aggregation timings
+age_mapping <- data.table(age_start = c(0, seq(0, 90, 5)), age_end = c(Inf, seq(5, 95, 5)))
+sex_mapping <- data.table(parent = "all", child = c("male", "female"))
+agg_id_vars <- list(
+  location = 1,
+  year_start = seq(1950, 2020, 1),
+  sex = c("male", "female"),
+  age_start = seq(0, 95, 1),
+  value1 = 1, value2 = 1
+)
+
+agg_timings <- lapply(profile_n_draws, function(n_draws) {
+  draw_timings <- list(
+    age_timing <- time_aggregation(
+      n_draws = n_draws,
+      id_vars = agg_id_vars,
+      col_stem = "age", col_type = "interval",
+      mapping = age_mapping
+    ),
+    sex_timing <- time_aggregation(
+      n_draws = n_draws,
+      id_vars = agg_id_vars,
+      col_stem = "sex", col_type = "categorical",
+      mapping = sex_mapping
+    )
+  )
+  draw_timings <- rbindlist(draw_timings)
+  return(draw_timings)
+})
+agg_timings <- rbindlist(agg_timings)
+```
+
+## Aggregation timing comparison
+
+This vignette makes aggregation timing comparisons between `hierarchyUtils` and `data.table` for example input data when aggregating across an interval variable like 'age' or a categorical variable like 'sex'.
+The example input data increases in size as more draws are added.
+
+### Example input data
+
+```{r example_input_data}
+# create input dataset
+agg_id_vars <- copy(agg_id_vars)
+agg_id_vars[["draw"]] <- 1:1
+input_dt <- do.call(CJ, agg_id_vars)
+input_dt
+```
+
+### Timing comparison
+
+```{r display_agg_timings, results="asis"}
+setcolorder(agg_timings, c("col_stem", "col_type", "n_draws", "method", "n_input_rows"))
+setkeyv(agg_timings, c("col_stem", "col_type", "n_draws", "method", "n_input_rows"))
+agg_timings[, c("user.child", "sys.child") := NULL]
+knitr::kable(agg_timings, )
+```

--- a/vignettes/agg_scale_performance.Rmd
+++ b/vignettes/agg_scale_performance.Rmd
@@ -180,7 +180,7 @@ input_dt
 ### Timing comparison
 
 ```{r display_agg_timings, results="asis"}
-setcolorder(agg_timings, c("col_stem", "col_type", "n_draws", "method", "n_input_rows", "elapsed"))
+setcolorder(agg_timings, c("col_stem", "col_type", "n_draws", "method", "n_input_rows"))
 setkeyv(agg_timings, c("col_stem", "col_type", "n_draws", "method", "n_input_rows"))
 agg_timings[, c("user.child", "sys.child") := NULL]
 knitr::kable(agg_timings)

--- a/vignettes/agg_scale_performance.Rmd
+++ b/vignettes/agg_scale_performance.Rmd
@@ -23,10 +23,22 @@ knitr::opts_chunk$set(
 library(hierarchyUtils)
 library(data.table)
 
-profile_n_draws <- c(1, 10)
+profile_n_draws <- c(1, 10, 100, 1000)
 ```
 
 ```{r time_aggregation_function}
+#' @title Helper function to time `hierarchyUtils::agg` and basic data.table
+#'   aggregation.
+#'
+#' @param n_draws \[`integer(1)`\]\cr
+#'   Number of draws to expand `id_vars` by.
+#' @param id_vars \[`list(1)`\]\cr
+#'   List of variables to expand to use as test input dataset. `id_vars` is
+#'   passed to `data.table::CJ`. Assumed to not include 'draw'. Assumed to include
+#'   'age_start' & 'year_start' but not the end variables.
+#' @inheritParams hierarchyUtils::agg
+#'
+#' @return \[`data.table(1)`\] containing summary information about the timing results.
 time_aggregation <- function(n_draws,
                              id_vars,
                              col_stem,
@@ -109,7 +121,7 @@ time_aggregation <- function(n_draws,
     setDT(elapsed_time)
     elapsed_time[, method := method]
     elapsed_time[, c("col_stem", "col_type") := list(col_stem, col_type)]
-    elapsed_time[, n_draws := format(n_draws, big.mark = ",", scientific = FALSE)]
+    elapsed_time[, n_draws := n_draws]
     elapsed_time[, n_input_rows := format(nrow(input_dt), big.mark = ",", scientific = FALSE)]
   })
   timings <- rbindlist(timings)
@@ -168,8 +180,8 @@ input_dt
 ### Timing comparison
 
 ```{r display_agg_timings, results="asis"}
-setcolorder(agg_timings, c("col_stem", "col_type", "n_draws", "method", "n_input_rows"))
+setcolorder(agg_timings, c("col_stem", "col_type", "n_draws", "method", "n_input_rows", "elapsed"))
 setkeyv(agg_timings, c("col_stem", "col_type", "n_draws", "method", "n_input_rows"))
 agg_timings[, c("user.child", "sys.child") := NULL]
-knitr::kable(agg_timings, )
+knitr::kable(agg_timings)
 ```


### PR DESCRIPTION
## Describe changes

This adds a small vignette comparing the speed of `hierarchyUtils::agg` to basic data.table code. As described in the vignette for basic use cases there should only be slightly more overhead due to the assertions and added flexibility included in `hierarchyUtils`.

This indicates there is still something slowing hierarchyUtils down that needs to be diagnosed.

## What issues are related

Related to #47

## Checklist

<!-- You can erase any parts of this checklist that are not applicable to your PR. -->

### Packages Repositories

* [X] Have you read the [contributing guidelines](https://github.com/ihmeuw-demographics/packageTemplate/wiki#guide-to-r-package-development) for `ihmeuw-demographics` R packages?
* [x] Have you successfully run `devtools::check()` locally?
* [ ] Have you updated or added function (and vignette if applicable) documentation? Did you update the 'man' and 'NAMESPACE' files with `devtools::document()`?
* [ ] Have you added in tests for the changes included in the PR?
* [X] Do the changes follow the `ihmeuw-demographics` [code style](https://github.com/ihmeuw-demographics/packageTemplate/wiki/Code-style-guide)?
* [ ] Do the changes need to be immediately included in a new build of [`docker-base`](https://github.com/ihmeuw-demographics/docker-base) or [`docker-internal`](https://github.com/ihmeuw-demographics/docker-internal)? If so follow directions in those repositories to rebuild and redeploy the images.
* [ ] Do the changes require updates to other repositories which use this package? If yes, make the necessary updates in those repos, and consider integration tests for those repositories.

## Details of PR

Example table of timings
```
> agg_timings
   col_stem    col_type n_draws         method n_input_rows user.self sys.self elapsed
1:      age    interval       1     data.table       13,632     0.057    0.006   0.065
2:      age    interval       1 hierarchyUtils       13,632     9.307    0.236   9.665
3:      age    interval      10     data.table      136,320     0.131    0.024   0.157
4:      age    interval      10 hierarchyUtils      136,320    46.943    0.630  47.835
5:      sex categorical       1     data.table       13,632     0.008    0.000   0.008
6:      sex categorical       1 hierarchyUtils       13,632     0.568    0.009   0.581
7:      sex categorical      10     data.table      136,320     0.055    0.008   0.063
8:      sex categorical      10 hierarchyUtils      136,320     4.786    0.090   4.908
```
