### PR TITLE
fix 'split_unknown' arguments check

### DIFF
--- a/R/split.R
+++ b/R/split.R
@@ -58,7 +58,13 @@
 #' )
 #'
 #' @export
-split_unknown <- function(dt, id_cols, value_cols, col_stem, col_type, mapping) {
+split_unknown <- function(dt,
+                          id_cols,
+                          value_cols,
+                          col_stem,
+                          col_type,
+                          mapping,
+                          quiet = FALSE) {
 
   # validate ----------------------------------------------------------------
 
@@ -70,10 +76,13 @@ split_unknown <- function(dt, id_cols, value_cols, col_stem, col_type, mapping) 
     ifelse(col_type == "interval", paste0(col_stem, "_start"), col_stem)
 
   assert_agg_scale_args(
-    dt[!is.na(get(col_stem_var))],
-    id_cols, value_cols, col_stem,
-    col_type, mapping, agg_function,
-    collapse_interval_cols, "agg"
+    dt = dt[!is.na(get(col_stem_var))],
+    id_cols = id_cols, value_cols = value_cols,
+    col_stem = col_stem, col_type = col_type,
+    mapping = mapping, agg_function = agg_function,
+    missing_dt_severity = "stop", overlapping_dt_severity = "stop",
+    na_value_severity = "stop", collapse_interval_cols = collapse_interval_cols,
+    functionality = "agg", quiet = quiet
   )
 
   demUtils::assert_is_unique_dt(dt, id_cols)

--- a/man/agg_scale.Rd
+++ b/man/agg_scale.Rd
@@ -229,7 +229,7 @@ when aggregating/scaling.
 \item \code{warning} or \code{message}: throw warning/message, drop overlapping intervals
 and continue with aggregation/scaling where possible (this may cause another
 error because of \code{missing_dt_severity}).
-3 \code{none}: don't throw error or warning, drop overlapping intervals and
+\item \code{none}: don't throw error or warning, drop overlapping intervals and
 continue with aggregation/scaling where possible (this may cause another
 error because of \code{missing_dt_severity}).
 \item \code{skip}: skip this check and continue with aggregation/scaling.

--- a/man/split_unknown.Rd
+++ b/man/split_unknown.Rd
@@ -4,7 +4,15 @@
 \alias{split_unknown}
 \title{Split unknown groupings}
 \usage{
-split_unknown(dt, id_cols, value_cols, col_stem, col_type, mapping)
+split_unknown(
+  dt,
+  id_cols,
+  value_cols,
+  col_stem,
+  col_type,
+  mapping,
+  quiet = FALSE
+)
 }
 \arguments{
 \item{dt}{[\code{data.table()}]\cr
@@ -30,6 +38,10 @@ is 'interval'.}
 \item{mapping}{[\code{character(1)}]\cr
 For 'categorical' variables, defines how different levels of the
 hierarchical variable relate to each other.}
+
+\item{quiet}{[\code{logical(1)}]\cr
+Should progress messages be suppressed as the function is run? Default is
+False.}
 }
 \value{
 [\code{data.table()}]\cr


### PR DESCRIPTION
## Describe changes

We updated `assert_agg_scale_args` arguments but didn't update the `split_unknown ` function call, this fixes that.

It sounds like @StefanieAW was trying to use this in v2020.0.15 docker image, is it okay to install this fix into that image?

## What issues are related

Related to https://github.com/ihmeuw-demographics/hierarchyUtils/pull/47
Related to https://github.com/ihmeuw-demographics/hierarchyUtils/pull/58

## Checklist

<!-- You can erase any parts of this checklist that are not applicable to your PR. -->

### Packages Repositories

* [x] Have you read the [contributing guidelines](https://github.com/ihmeuw-demographics/packageTemplate/wiki#guide-to-r-package-development) for `ihmeuw-demographics` R packages?
* [x] Have you successfully run `devtools::check()` locally?
* [x] Have you updated or added function (and vignette if applicable) documentation? Did you update the 'man' and 'NAMESPACE' files with `devtools::document()`?
* [x] Have you added in tests for the changes included in the PR?
* [x] Do the changes follow the `ihmeuw-demographics` [code style](https://github.com/ihmeuw-demographics/packageTemplate/wiki/Code-style-guide)?
* [ ] Do the changes need to be immediately included in a new build of [`docker-base`](https://github.com/ihmeuw-demographics/docker-base) or [`docker-internal`](https://github.com/ihmeuw-demographics/docker-internal)? If so follow directions in those repositories to rebuild and redeploy the images.
* [ ] Do the changes require updates to other repositories which use this package? If yes, make the necessary updates in those repos, and consider integration tests for those repositories.
