### PR TITLE
add interval mapping assertion

### DIFF
--- a/R/agg_scale.R
+++ b/R/agg_scale.R
@@ -634,6 +634,14 @@ assert_agg_scale_args <- function(dt,
                                    `dt`")
   }
 
+  if (functionality == "agg" & col_type == "interval") {
+    invalid_interval_mapping <- mapping[get(cols[1]) >= get(cols[2])]
+    assertthat::assert_that(
+      nrow(invalid_interval_mapping) == 0,
+      msg = "interval 'start' columns must always be less than the corresponding
+             'end' column, check `mapping` argument")
+  }
+
   # check `agg_function` argument
   assertthat::assert_that(assertive::is_function(agg_function),
                           identical(agg_function, sum) |


### PR DESCRIPTION
## Describe changes

Adds simple assertion that the lower interval must be less than the upper interval

## What issues are related

Fixes #42 

## Checklist

<!-- You can erase any parts of this checklist that are not applicable to your PR. -->

### Packages Repositories

* [x] Have you read the [contributing guidelines](https://github.com/ihmeuw-demographics/packageTemplate/wiki#guide-to-r-package-development) for `ihmeuw-demographics` R packages?
* [x] Have you successfully run `devtools::check()` locally?
* [x] Have you updated or added function (and vignette if applicable) documentation? Did you update the 'man' and 'NAMESPACE' files with `devtools::document()`?
* [x] Have you added in tests for the changes included in the PR?
* [x] Do the changes follow the `ihmeuw-demographics` [code style](https://github.com/ihmeuw-demographics/packageTemplate/wiki/Code-style-guide)?
* [ ] Do the changes need to be immediately included in a new build of [`docker-base`](https://github.com/ihmeuw-demographics/docker-base) or [`docker-internal`](https://github.com/ihmeuw-demographics/docker-internal)? If so follow directions in those repositories to rebuild and redeploy the images.
* [ ] Do the changes require updates to other repositories which use this package? If yes, make the necessary updates in those repos, and consider integration tests for those repositories.
* [ ] If this is a private package did you use Jenkins to rebuild the internal pkgdown site?
