### PR TITLE
option to identify all possible overlapping intervals

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Suggests:
     ggplot2,
     scales
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 VignetteBuilder: knitr
 Language: en-US
 Depends: R (>= 2.10)

--- a/R/interval_collapse.R
+++ b/R/interval_collapse.R
@@ -137,7 +137,7 @@ collapse_common_intervals <- function(dt,
   # check for overlapping intervals
   if (overlapping_dt_severity != "skip") {
     overlapping_dt <- dt[
-      , identify_overlapping_intervals(unique(.SD)),
+      , identify_overlapping_intervals(unique(.SD), identify_all_possible = overlapping_dt_severity != "none"),
       .SDcols = cols, by = by_id_cols
       ]
     data.table::setnames(overlapping_dt, c("start", "end"), cols)

--- a/man/overlapping_intervals.Rd
+++ b/man/overlapping_intervals.Rd
@@ -7,12 +7,17 @@
 \usage{
 assert_no_overlapping_intervals(ints_dt)
 
-identify_overlapping_intervals(ints_dt)
+identify_overlapping_intervals(ints_dt, identify_all_possible = FALSE)
 }
 \arguments{
 \item{ints_dt}{[\code{data.table()}]\cr
 Unique intervals. The first column represents the start of each interval
 and the second column represents the end of each interval.}
+
+\item{identify_all_possible}{[\code{logical(1)}]\cr
+Whether to return all overlapping intervals ('TRUE') or try to identify just
+the less granular interval ('FALSE'). Default is 'FALSE'. Useful when it may
+not be clear what is the less granular interval.}
 }
 \value{
 \code{identify_overlapping_intervals} returns a [\code{data.table()}] with
@@ -27,10 +32,11 @@ overlapping intervals.
 }
 \examples{
 ints_dt <- data.table::data.table(
-  start = c(seq(0, 95, 5), 0),
-  end = c(seq(5, 95, 5), Inf, Inf)
+  start = c(seq(10, 50, 5), 0),
+  end = c(seq(15, 55, 5), 11)
 )
-overlapping_dt <- identify_overlapping_intervals(ints_dt)
+overlapping_dt <- identify_overlapping_intervals(ints_dt, identify_all_possible = FALSE)
+overlapping_dt <- identify_overlapping_intervals(ints_dt, identify_all_possible = TRUE)
 
 
 }

--- a/tests/testthat/test-interval_assertions.R
+++ b/tests/testthat/test-interval_assertions.R
@@ -46,19 +46,19 @@ ints_dt <- data.table(
 
 testthat::test_that("missing intervals are identified correctly", {
 
-
   testthat::expect_silent(
     assert_no_overlapping_intervals(ints_dt)
   )
 
-  expected_overlapping_dt <- data.table(
-    start = c(15),
-    end = c(60)
-  )
-
+  expected_overlapping_dt <- data.table(start = c(15), end = c(60))
   ints_dt <- rbind(ints_dt, expected_overlapping_dt)
 
-  overlapping_dt <- identify_overlapping_intervals(ints_dt)
+  overlapping_dt <- identify_overlapping_intervals(ints_dt, identify_all_possible = FALSE)
+  setkeyv(expected_overlapping_dt, c("start", "end"))
+  testthat::expect_equal(overlapping_dt, expected_overlapping_dt)
+
+  overlapping_dt <- identify_overlapping_intervals(ints_dt, identify_all_possible = TRUE)
+  expected_overlapping_dt <- ints_dt[start >= 15 & end <= 60]
   setkeyv(expected_overlapping_dt, c("start", "end"))
   testthat::expect_equal(overlapping_dt, expected_overlapping_dt)
 


### PR DESCRIPTION
## Describe changes

To help with overlapping intervals where it may not be clear what is truly the less granular interval.

Like: 0-11, 10-15, 15-20 as specified in #66.

We can visually inspect and know 0-11 is the messed up age group likely, but before this PR only 10-15 was flagged as overlapping. Now if `identify_all_possible=TRUE` is specified, both 0-11 and 10-15 are flagged for manual inspection.

## Checklist

<!-- You can erase any parts of this checklist that are not applicable to your PR. -->

### Packages Repositories

* [x] Have you read the [contributing guidelines](https://github.com/ihmeuw-demographics/packageTemplate/wiki#guide-to-r-package-development) for `ihmeuw-demographics` R packages?
* [x] Have you successfully run `devtools::check()` locally?
* [x] Have you updated or added function (and vignette if applicable) documentation? Did you update the 'man' and 'NAMESPACE' files with `devtools::document()`?
* [x] Have you added in tests for the changes included in the PR?
* [x] Do the changes follow the `ihmeuw-demographics` [code style](https://github.com/ihmeuw-demographics/packageTemplate/wiki/Code-style-guide)?
* [ ] Do the changes need to be immediately included in a new build of [`docker-base`](https://github.com/ihmeuw-demographics/docker-base) or [`docker-internal`](https://github.com/ihmeuw-demographics/docker-internal)? If so follow directions in those repositories to rebuild and redeploy the images.
* [ ] Do the changes require updates to other repositories which use this package? If yes, make the necessary updates in those repos, and consider integration tests for those repositories.
* [ ] If this is a private package did you use Jenkins to rebuild the internal pkgdown site?
