### PR TITLE
fix aggregation when nothing possible #67

### DIFF
--- a/R/agg_scale.R
+++ b/R/agg_scale.R
@@ -311,7 +311,7 @@ agg <- function(dt,
 
   # create object to collect aggregated results
   result_dt <- dt[0]
-  if (col_type == "interval") result_dt <- vector("list", length(subtrees))
+  if (col_type == "interval") result_dt <- lapply(1:length(subtrees), function(i) dt[0])
 
   # aggregate children to parents for sub-trees where aggregation possible
   for (i in 1:length(subtrees)) {

--- a/R/agg_scale.R
+++ b/R/agg_scale.R
@@ -342,10 +342,10 @@ agg <- function(dt,
                  paste0(capture.output(missing_dt), collapse = "\n"))
         assertive::assert_engine(empty_missing_dt, missing_dt,
                                  msg = error_msg, severity = missing_dt_severity)
-      }
 
-      # skip aggregation for this subtree
-      next()
+        # skip aggregation for this subtree
+        next()
+      }
     }
 
     # check if aggregate is already present

--- a/tests/testthat/test_agg.R
+++ b/tests/testthat/test_agg.R
@@ -257,6 +257,31 @@ testthat::test_that(description, {
   )
 })
 
+# no possible aggregates to make ------------------------------------------
+
+input_dt <- data.table(year = 2010, age_start = seq(15, 50, 5), age_end = seq(20, 55, 5), value = 1)
+description <- "no error is thrown when there are no possible aggregates to make"
+testthat::test_that(description, {
+
+  expect_error(
+    agg(
+      dt = input_dt,
+      id_cols = c("year", "age_start", "age_end"), value_col = "value",
+      col_stem = "age", col_type = "interval",
+      mapping = data.table(age_start = 10, age_end = 55)
+    ),
+    regexp = "expected input data is missing"
+  )
+
+  output_dt <- agg(
+    dt = input_dt,
+    id_cols = c("year", "age_start", "age_end"), value_col = "value",
+    col_stem = "age", col_type = "interval",
+    mapping = data.table(age_start = 10, age_end = 55),
+    missing_dt_severity = "none"
+  )
+  expect_equal(nrow(output_dt), 0)
+})
 
 # Aggregate categorical variable with multiple levels in mapping ----------
 

--- a/tests/testthat/test_agg.R
+++ b/tests/testthat/test_agg.R
@@ -281,6 +281,15 @@ testthat::test_that(description, {
     missing_dt_severity = "none"
   )
   expect_equal(nrow(output_dt), 0)
+
+  output_dt <- agg(
+    dt = input_dt,
+    id_cols = c("year", "age_start", "age_end"), value_col = "value",
+    col_stem = "age", col_type = "interval",
+    mapping = data.table(age_start = 10, age_end = 55),
+    missing_dt_severity = "skip"
+  )
+  expect_equal(output_dt, data.table(year = 2010, age_start = 10, age_end = 55, value = nrow(input_dt)))
 })
 
 # Aggregate categorical variable with multiple levels in mapping ----------


### PR DESCRIPTION
## Describe changes

Fixes #67, flagged by @hcomfo95. Where the requested aggregate was age 10-55 but data only had 15-55. Called with `missing_dt_severity = "none"`. Since the requested aggregate is not possible, the function should have returned an empty data.table but was instead erroring out with an obscure error.

```
none: don't throw error or warning, continue with aggregation/scaling for requested aggregations/scalings where expected input data in dt is available.

skip: skip this check and continue with aggregation/scaling.
```

If instead @hcomfo95 expected to still make the aggregate even though it was missing input age group values I fixed `missing_dt_severity = "skip"` so that it still goes ahead and makes the aggregate.

@erinamay I were talking about a similar situation this week where there are implied zeroes or unknown values in the input dataset. Like in this example 10-15 is unknown or implied zero. We likely need helper functions to fill in implied zeroes and then a better way to handle unknown id columns (like age) or value columns. Related to #49 and #65

## Checklist

<!-- You can erase any parts of this checklist that are not applicable to your PR. -->

### Packages Repositories

* [X] Have you read the [contributing guidelines](https://github.com/ihmeuw-demographics/packageTemplate/wiki#guide-to-r-package-development) for `ihmeuw-demographics` R packages?
* [X] Have you successfully run `devtools::check()` locally?
* [X] Have you updated or added function (and vignette if applicable) documentation? Did you update the 'man' and 'NAMESPACE' files with `devtools::document()`?
* [X] Have you added in tests for the changes included in the PR?
* [X] Do the changes follow the `ihmeuw-demographics` [code style](https://github.com/ihmeuw-demographics/packageTemplate/wiki/Code-style-guide)?
* [ ] Do the changes need to be immediately included in a new build of [`docker-base`](https://github.com/ihmeuw-demographics/docker-base) or [`docker-internal`](https://github.com/ihmeuw-demographics/docker-internal)? If so follow directions in those repositories to rebuild and redeploy the images.
* [ ] Do the changes require updates to other repositories which use this package? If yes, make the necessary updates in those repos, and consider integration tests for those repositories.
* [ ] If this is a private package did you use Jenkins to rebuild the internal pkgdown site?