### PR TITLE
fix missing intervals check when no additional id_cols specified

### DIFF
--- a/R/interval_assertions.R
+++ b/R/interval_assertions.R
@@ -161,7 +161,12 @@ identify_missing_intervals_dt <- function(dt,
     # combine missing intervals with group dataset
     if (nrow(missing_ints) > 0) {
       data.table::setnames(missing_ints, c("start", "end"), cols)
-      missing_ints <- CJDT(group_dt, missing_ints)
+
+      # as long as group dt includes other id_cols
+      if (!(nrow(group_dt) == 0 & ncol(group_dt) == 0)) {
+        missing_ints <- CJDT(group_dt, missing_ints)
+      }
+
     } else {
       missing_ints <- dt[0, id_cols, with = FALSE]
     }

--- a/tests/testthat/test-interval_assertions.R
+++ b/tests/testthat/test-interval_assertions.R
@@ -1,6 +1,44 @@
 
 # Missing intervals -------------------------------------------------------
 
+test_missing_intervals <- function(description,
+                                   dt, id_cols, expected_ints_dt,
+                                   drop_age_starts) {
+
+  testthat::test_that(description, {
+
+    missing_dt <- identify_missing_intervals_dt(
+      dt = dt[!age_start %in% drop_age_starts],
+      id_cols = id_cols,
+      col_stem = "age",
+      expected_ints_dt = expected_ints_dt
+    )
+    testthat::expect_equal(missing_dt, dt[age_start %in% drop_age_starts, id_cols, with = FALSE])
+
+    testthat::expect_error(
+      assert_no_missing_intervals_dt(
+        dt = dt[!age_start %in% drop_age_starts],
+        id_cols = id_cols,
+        col_stem = "age",
+        expected_ints_dt = expected_ints_dt
+      ),
+      regexp = "There are missing intervals"
+    )
+
+    testthat::expect_error(
+      assert_no_missing_intervals_dt(
+        dt = dt,
+        id_cols = id_cols,
+        col_stem = "age",
+        expected_ints_dt = expected_ints_dt
+      ),
+      NA
+    )
+  })
+}
+
+# test multiple groupings
+drop_age_starts <- c(0, 10, 95)
 id_cols <- c("year", "age_start", "age_end")
 
 input_dt <- data.table(
@@ -16,36 +54,23 @@ expected_ints_dt <- data.table(
   age_end = Inf
 )
 
-testthat::test_that("missing intervals are identified correctly", {
+test_missing_intervals(
+  description = "missing intervals are identified correctly",
+  input_dt, id_cols, expected_ints_dt, drop_age_starts
+)
 
-  missing_dt <- identify_missing_intervals_dt(
-    dt = input_dt[!age_start %in% c(0, 10, 95)],
-    id_cols = id_cols,
-    col_stem = "age",
-    expected_ints_dt = expected_ints_dt
-  )
-  testthat::expect_equal(missing_dt, input_dt[age_start %in% c(0, 10, 95), id_cols, with = FALSE])
+# test single grouping with no additional id_cols
+input_dt <- data.table(
+  age_start = seq(0, 95, 5),
+  age_end = c(seq(5, 95, 5), Inf),
+  value = 1
+)
+id_cols <- c("age_start", "age_end")
 
-  testthat::expect_error(
-    assert_no_missing_intervals_dt(
-      dt = input_dt[!age_start %in% c(0, 10, 95)],
-      id_cols = id_cols,
-      col_stem = "age",
-      expected_ints_dt = expected_ints_dt
-    ),
-    regexp = "There are missing intervals"
-  )
-
-  testthat::expect_error(
-    assert_no_missing_intervals_dt(
-      dt = input_dt,
-      id_cols = id_cols,
-      col_stem = "age",
-      expected_ints_dt = expected_ints_dt
-    ),
-    NA
-  )
-})
+test_missing_intervals(
+  description = "missing intervals are identified correctly when no extra id_cols are included",
+  input_dt, id_cols, expected_ints_dt, drop_age_starts
+)
 
 # Overlapping intervals ---------------------------------------------------
 


### PR DESCRIPTION
## Describe changes

fix missing intervals check when no additional id_cols specified. For example only specifying `id_cols = c("age_start", "age_end")`. This should have worked but was failing when merging back onto the original dataset.

## Checklist

<!-- You can erase any parts of this checklist that are not applicable to your PR. -->

### Packages Repositories

* [X] Have you read the [contributing guidelines](https://github.com/ihmeuw-demographics/packageTemplate/wiki#guide-to-r-package-development) for `ihmeuw-demographics` R packages?
* [X] Have you successfully run `devtools::check()` locally?
* [] Have you updated or added function (and vignette if applicable) documentation? Did you update the 'man' and 'NAMESPACE' files with `devtools::document()`?
* [X] Have you added in tests for the changes included in the PR?
* [X] Do the changes follow the `ihmeuw-demographics` [code style](https://github.com/ihmeuw-demographics/packageTemplate/wiki/Code-style-guide)?
* [ ] Do the changes need to be immediately included in a new build of [`docker-base`](https://github.com/ihmeuw-demographics/docker-base) or [`docker-internal`](https://github.com/ihmeuw-demographics/docker-internal)? If so follow directions in those repositories to rebuild and redeploy the images.
* [ ] Do the changes require updates to other repositories which use this package? If yes, make the necessary updates in those repos, and consider integration tests for those repositories.
