### PR TITLE
Completely remove assertive/assertive.base dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Suggests:
     ggplot2,
     scales
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.3
 VignetteBuilder: knitr
 Language: en-US
 Depends: R (>= 2.10)
@@ -34,7 +34,6 @@ Imports:
     demUtils,
     data.table,
     assertthat,
-    assertive.base,
     assertable (>= 0.2.7),
     checkmate,
     data.tree,

--- a/R/agg_helpers.R
+++ b/R/agg_helpers.R
@@ -1,3 +1,17 @@
+#' originally based on assertive.base::assert_engine which got dropped from cran
+#' @noRd
+assert_engine_copy <- function(predicate, ..., msg, severity = c("stop", "warning", "message", "none")) {
+
+  severity <- match.arg(severity)
+  value <- predicate(...)
+
+  if (!value & severity != "none") {
+    severity_func <- get(severity)
+    severity_func(msg)
+  }
+  return(invisible(value))
+}
+
 #' @title Helper function to aggregate categorical variables
 #'
 #' @description Helper function to aggregate categorical variables or square
@@ -61,8 +75,12 @@ agg_categorical <- function(dt,
                  "* See `missing_dt_severity` argument if it is okay to only make ",
                  "aggregate/scale data that are possible given what is available.\n",
                  paste0(capture.output(missing_dt), collapse = "\n"))
-        assertive.base::assert_engine(empty_missing_dt, missing_dt,
-                                 msg = error_msg, severity = missing_dt_severity)
+        assert_engine_copy(
+          predicate = empty_missing_dt,
+          missing_dt,
+          msg = error_msg,
+          severity = missing_dt_severity
+        )
 
         # skip aggregation for this subtree
         next()
@@ -79,8 +97,12 @@ agg_categorical <- function(dt,
                "* See `present_agg_severity` argument if it is okay to aggregate
              multiple rows with the available data.\n",
                paste0(capture.output(parent_dt), collapse = "\n"))
-      assertive.base::assert_engine(empty_dt, parent_dt,
-                               msg = error_msg, severity = present_agg_severity)
+      assert_engine_copy(
+        predicate = empty_dt,
+        parent_dt,
+        msg = error_msg,
+        severity = present_agg_severity
+      )
 
       # drop parent data already present
       if (nrow(parent_dt) > 0) {
@@ -198,8 +220,12 @@ agg_interval <- function(dt,
         paste0("Some overlapping intervals were identified in `dt`.\n",
                "Will attempt to drop the larger intervals.\n",
                paste0(capture.output(overlapping_dt), collapse = "\n"))
-      assertive.base::assert_engine(empty_dt, overlapping_dt,
-                               msg = error_msg, severity = overlapping_dt_severity)
+      assert_engine_copy(
+        predicate = empty_dt,
+        overlapping_dt,
+        msg = error_msg,
+        severity = overlapping_dt_severity
+      )
 
       # drop overlapping intervals
       if (nrow(overlapping_dt) > 0) {

--- a/R/agg_scale.R
+++ b/R/agg_scale.R
@@ -375,8 +375,12 @@ scale <- function(dt,
                    "* See `missing_dt_severity` argument if it is okay to only make ",
                    "aggregate/scale data that are possible given what is available.\n",
                    paste0(capture.output(missing_dt), collapse = "\n"))
-          assertive.base::assert_engine(empty_missing_dt, missing_dt,
-                                   msg = error_msg, severity = missing_dt_severity)
+          assert_engine_copy(
+            predicate = empty_missing_dt,
+            missing_dt,
+            msg = error_msg,
+            severity = missing_dt_severity
+          )
         }
       } else { # additional check for overlapping intervals in the children nodes
         if (col_type == "interval") {
@@ -388,8 +392,12 @@ scale <- function(dt,
             error_msg <-
               paste0("Some overlapping intervals are in `dt`.\n",
                      paste0(capture.output(overlapping_dt), collapse = "\n"))
-            assertive.base::assert_engine(empty_dt, overlapping_dt,
-                                     msg = error_msg, severity = overlapping_dt_severity)
+            assert_engine_copy(
+              predicate = empty_dt,
+              overlapping_dt,
+              msg = error_msg,
+              severity = overlapping_dt_severity
+            )
           }
         }
       }
@@ -568,8 +576,12 @@ assert_agg_scale_args <- function(dt,
              "* See `na_value_severity` argument if it is okay to propagate ",
              "NA values or to drop NA values and continue.\n",
              paste0(capture.output(na_value_dt), collapse = "\n"))
-    assertive.base::assert_engine(empty_na_value_dt, na_value_dt,
-                             msg = error_msg, severity = na_value_severity)
+    assert_engine_copy(
+      predicate = empty_na_value_dt,
+      na_value_dt,
+      msg = error_msg,
+      severity = na_value_severity
+    )
 
     # drop na value rows and continue
     if (!empty_na_value_dt(na_value_dt)) dt <- na.omit(dt, cols = value_cols)

--- a/R/categorical_trees.R
+++ b/R/categorical_trees.R
@@ -733,8 +733,12 @@ check_agg_scale_subtree_dt <- function(dt,
              "* See `missing_dt_severity` argument if it is okay to only make ",
              "aggregate/scale data that are possible given what is available.\n",
              paste0(capture.output(missing_dt), collapse = "\n"))
-    assertive.base::assert_engine(empty_missing_dt, missing_dt,
-                             msg = error_msg, severity = missing_dt_severity)
+    assert_engine_copy(
+      predicate = empty_missing_dt,
+      missing_dt,
+      msg = error_msg,
+      severity = missing_dt_severity
+    )
 
     # if missing data but `missing_dt_severity` is not 'error' then drop missing data
     if (nrow(missing_dt) > 0) {

--- a/R/interval_collapse.R
+++ b/R/interval_collapse.R
@@ -148,8 +148,12 @@ collapse_common_intervals <- function(dt,
       paste0("Some overlapping intervals were identified in `dt`.\n",
              "These will be automatically dropped.\n",
              paste0(capture.output(overlapping_dt), collapse = "\n"))
-    assertive.base::assert_engine(empty_dt, overlapping_dt,
-                             msg = error_msg, severity = overlapping_dt_severity)
+    assert_engine_copy(
+      predicate = empty_dt,
+      overlapping_dt,
+      msg = error_msg,
+      severity = overlapping_dt_severity
+    )
 
     # drop overlapping intervals
     dt <- merge(dt, overlapping_dt, by = id_cols, all = T)
@@ -178,8 +182,12 @@ collapse_common_intervals <- function(dt,
       paste0("Some intervals in `dt` are missing making it impossible to collapse ",
              "the desired column.\n",
              paste0(capture.output(missing_dt), collapse = "\n"))
-    assertive.base::assert_engine(empty_missing_dt, missing_dt,
-                             msg = error_msg, severity = missing_dt_severity)
+    assert_engine_copy(
+      predicate = empty_missing_dt,
+      missing_dt,
+      msg = error_msg,
+      severity = missing_dt_severity
+    )
 
     # drop the common intervals that the missing intervals are part of
     if (nrow(missing_dt) > 0) {


### PR DESCRIPTION
Hey @spencerpease & @krpaulson. I tried to install/use hierarchyUtils yesterday but assertive.base also got removed from cran so I wasn't able to install without these changes.

I created a light implementation of 'assert_engine' so that there isn't an immediate need to change all the dependent functions & documentation. The tests and package check seemed to pass fine on my local machine.

Related to #83 